### PR TITLE
added a link to org top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [w3ckeio.github.io](https://w3ckeio.github.io)は将来的に[W3Cサイト](https://w3.org)のKeioサブサイト内に配置する予定のコンテンツ開発スペースです。
+レポジトリ一覧は[GitHub w3ckeio organizationトップページ](https://github.com/w3ckeio)を参照ください。
 
 * [W3Cアップデートの月間サマリー](monthly-summary/)
 * [用語集](glossary/)


### PR DESCRIPTION
プライベートレポジトリもあるかもしれないことを思うと、レポジトリ一覧へのリンクはトップに飛ばすのはどうでしょうか？