### PR TITLE
W3C jekyllのトライ

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,10 @@
+# gh-pages jekyll W3C theme
+title: W3C Japan unofficial page
+email: keio-contact@w3.org
+description: >
+  Leading the Web to its Full Potential
+member_only: false
+baseurl: "/"
+remote_theme: w3c/w3c-jekyll-theme
+plugins:
+- jekyll-remote-theme


### PR DESCRIPTION
@yonaomi 
試しにW3Cサイト用のjekyllテンプレートを突っ込んでみたのですが、さすがにこれを適用するのは微妙すぎますね。。。
[参考出力](https://himorin.github.io/w3ckeio.github.io/monthly-summary/)でご覧ください。ただし右側のナビゲーション関係のデータを入れてない(ので本文領域の右側が妙に空いてる)のと、PRマージ後に動くディレクトリの設定でやってるので上部にオレンジ枠のエラーが出ますが、そのあたりは無視していただいて。